### PR TITLE
Remove 1 unnecessary stubbing in GoogleRobotPrivateKeyCredentialsTest.testCreatePrivateKeyCredentialsWithP12KeyType

### DIFF
--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentialsTest.java
@@ -141,7 +141,6 @@ public class GoogleRobotPrivateKeyCredentialsTest {
   public void testCreatePrivateKeyCredentialsWithP12KeyType() throws Exception {
     when(mockFileItem.getSize()).thenReturn(1L);
     when(mockFileItem.getName()).thenReturn(p12KeyPath);
-    when(mockFileItem.getInputStream()).thenReturn(new FileInputStream(p12KeyPath));
     when(mockFileItem.get()).thenReturn(FileUtils.readFileToByteArray(new File(p12KeyPath)));
     P12ServiceAccountConfig keyType = new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
     keyType.setP12KeyFileUpload(mockFileItem);


### PR DESCRIPTION
In our analysis of the project, we observed that the test `GoogleRobotPrivateKeyCredentialsTest.testCreatePrivateKeyCredentialsWithP12KeyType` contains 1 unnecessary stubbing. Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). We propose below a solution to remove the unnecessary stubbing.