### PR TITLE
Remove 2 unnecessary stubbings in JsonServiceAccountConfigTest.testCreateJsonKeyTypeWithInvalidJsonKeyFile

### DIFF
--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/JsonServiceAccountConfigTest.java
@@ -92,9 +92,7 @@ public class JsonServiceAccountConfigTest {
   public void testCreateJsonKeyTypeWithInvalidJsonKeyFile() throws Exception {
     byte[] bytes = "invalidJsonKeyFile".getBytes();
     when(mockFileItem.getSize()).thenReturn((long) bytes.length);
-    when(mockFileItem.getName()).thenReturn(jsonKeyPath);
     when(mockFileItem.getInputStream()).thenReturn(new ByteArrayInputStream(bytes));
-    when(mockFileItem.get()).thenReturn(bytes);
     JsonServiceAccountConfig jsonServiceAccountConfig = new JsonServiceAccountConfig();
     jsonServiceAccountConfig.setJsonKeyFileUpload(mockFileItem);
 


### PR DESCRIPTION
In our analysis of the project, we observed that the test `JsonServiceAccountConfigTest.testCreateJsonKeyTypeWithInvalidJsonKeyFile` contains 2 unnecessary stubbings. Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). We propose below a solution to remove the unnecessary stubbing.