### PR TITLE
Remove 1 unnecessary stubbing in P12ServiceAccountConfigTest.testCreateWithEmptyP12KeyFile

### DIFF
--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/P12ServiceAccountConfigTest.java
@@ -92,7 +92,6 @@ public class P12ServiceAccountConfigTest {
   @WithoutJenkins
   public void testCreateWithEmptyP12KeyFile() throws Exception {
     when(mockFileItem.getSize()).thenReturn(0L);
-    when(mockFileItem.get()).thenReturn(new byte[] {});
     P12ServiceAccountConfig p12ServiceAccountConfig =
         new P12ServiceAccountConfig(SERVICE_ACCOUNT_EMAIL_ADDRESS);
     p12ServiceAccountConfig.setP12KeyFileUpload(mockFileItem);


### PR DESCRIPTION
In our analysis of the project, we observed that the test `P12ServiceAccountConfigTest.testCreateWithEmptyP12KeyFile` contains 1 unnecessary stubbing. Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). We propose below a solution to remove the unnecessary stubbing.